### PR TITLE
Test Iteration (0.2.1) - Fix Modulefile

### DIFF
--- a/ncsa_build/3.0.2.lua
+++ b/ncsa_build/3.0.2.lua
@@ -26,7 +26,7 @@ setenv("XALT_EXECUTABLE_TRACKING",       "yes")
 -- Environment variables for XALT to run on a Compute Node
 prepend_path{"PATH",          bin, priority="100"}
 prepend_path("XALT_DIR",      base)
-prepend_path("LD_PRELOAD",    pathJoin(base, "$LIB/libxalt_init.so"))
+prepend_path("LD_PRELOAD",    pathJoin(base, "lib64/libxalt_init.so"))
 prepend_path("COMPILER_PATH", bin)
 
 -- XAlT_DATE_TIME creation


### PR DESCRIPTION
_Modifications_
- Changed $LIB to lib64 in `ncsa_build/3.0.2.lua`

_Why_
Hotfix to resolve $LIB not getting replaced with lib64
ERROR: ld.so: object '/sw/workload/xalt2/xalt/xalt/$LIB/libxalt_init.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
